### PR TITLE
feat: add conventional commit validation and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: 'weekly'
     labels:
       - 'dependencies'
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
@@ -15,3 +19,6 @@ updates:
       interval: 'weekly'
     labels:
       - 'dependencies'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,40 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          types: |
+            fix
+            feat
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          scopes: |
+            deps
+            deps-dev
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to validate PR titles follow conventional commit format
- Configure Dependabot to automatically create PRs with conventional commit messages
- Standardize commit messages across the repository for better automation

## Changes
- Created `.github/workflows/pr-title-check.yml` to validate PR titles
- Updated `.github/dependabot.yml` to use conventional commit format:
  - `fix(deps):` for production dependencies
  - `chore(deps-dev):` for development dependencies  
  - `chore(deps):` for GitHub Actions updates

## Test Plan
- [ ] PR title validation workflow runs on this PR
- [ ] Next Dependabot PR should use conventional commit format
- [ ] Workflow correctly validates conventional commit format

🤖 Generated with [Claude Code](https://claude.ai/code)