### PR TITLE
refactor(ci): add shared ci success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,20 @@ jobs:
       - name: Run license check
         run: npx license-checker --production --summary
         continue-on-error: true
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [ci, security]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      statuses: read
+
+    steps:
+      - name: Wait for all PR checks to succeed
+        uses: promptfoo/.github/.github/actions/ci-success@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          timeout-seconds: 300

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,6 +30,7 @@ jobs:
           scopes: |
             deps
             deps-dev
+            ci
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |


### PR DESCRIPTION
Add a CI Success job to the existing CI workflow, use the shared first-party action from promptfoo/.github, and keep the current PR Title Check workflow intact. Test plan: verify the workflow parses and CI Success waits for the existing PR checks.